### PR TITLE
Remove useless and inconsitent pointer check

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -988,8 +988,8 @@ void CCharacter::TakeHammerHit(CCharacter* pFrom)
 
 	m_Core.m_Vel += Push;
 
-	CPlayer* pPlayer = pFrom->GetPlayer();
-	if (pPlayer && (GameServer()->m_pController->IsTeamplay() && pPlayer->GetTeam() == m_pPlayer->GetTeam()))
+	CPlayer *pPlayer = pFrom->GetPlayer();
+	if (GameServer()->m_pController->IsTeamplay() && pPlayer->GetTeam() == m_pPlayer->GetTeam())
 	{
 		m_Killer.m_uiKillerHookTicks = 0;
 		m_Killer.m_KillerID = m_pPlayer->GetCID();


### PR DESCRIPTION
pPlayer is used unchecked in the else branch (which is fine) And is checked in the happy branch (which is not needed).

CPlayer pointers from CCharacter::GetPlayer() should be safe at all times There is no character without player