### PR TITLE
Rename false spike to wrong spike in configs

### DIFF
--- a/fng.cfg
+++ b/fng.cfg
@@ -59,15 +59,15 @@ sv_score_display 0
 # sv_team_score_normal 5
 # sv_team_score_team 10
 # sv_team_score_gold 10
-# sv_team_score_false -2
+# sv_team_score_wrong -2
 
 # sv_player_score_normal 3
 # sv_player_score_team 5
 # sv_player_score_gold 7
-# sv_player_score_false -5
+# sv_player_score_wrong -5
 
-# the seconds a player gets frozen, when he makes a false spike kill
-# sv_false_spike_freeze 5
+# the seconds a player gets frozen, when he tries to score using the opponents team spike
+# sv_wrong_spike_freeze 5
 # sv_hit_freeze 10
 
 # delay of emoicon input (0 = emoticon spam)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -817,10 +817,10 @@ void CCharacter::DieSpikes(int pPlayerID, int spikes_flag) {
 			Msg.m_ModeSpecial = ModeSpecial;
 			GameServer()->SendPackMsg(&Msg, MSGFLAG_VITAL);
 
-			if (GameServer()->m_pController->IsTeamplay() && GameServer()->m_pController->IsFalseSpike(GameServer()->m_apPlayers[pPlayerID]->GetTeam(), spikes_flag)) {
+			if (GameServer()->m_pController->IsTeamplay() && GameServer()->m_pController->IsWrongSpike(GameServer()->m_apPlayers[pPlayerID]->GetTeam(), spikes_flag)) {
 				CCharacter* pKiller = ((CPlayer*)GameServer()->m_apPlayers[pPlayerID])->GetCharacter();
 				if (pKiller && !pKiller->IsFrozen()) {
-					pKiller->Freeze(g_Config.m_SvFalseSpikeFreeze);
+					pKiller->Freeze(g_Config.m_SvWrongSpikeFreeze);
 					GameServer()->CreateSound(pKiller->m_Pos, SOUND_TEE_CRY);
 				}
 			}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1285,14 +1285,14 @@ void CGameContext::CmdStats(CGameContext* pContext, int pClientID, const char** 
 		"║Normal: %d\n"
 		"║Team: %d\n"
 		"║Gold/Green/Purple: %d/%d/%d\n"
-		"║False: %d\n"
+		"║Wrong: %d\n"
 		"║Deaths(while frozen): %d\n"
 		"║\n"
 		"╠═══════════ Misc ══════════\n"
 		"║\n"
 		"║Mates hammer-/unfrozen: %d/%d\n"
 		"║\n"
-		"╚══════════════════════════\n", p->m_Stats.m_Kills, p->m_Stats.m_Hits, (p->m_Stats.m_Hits != 0) ? (float)((float)p->m_Stats.m_Kills / (float)p->m_Stats.m_Hits) : (float)p->m_Stats.m_Kills, p->m_Stats.m_Shots, ((float)p->m_Stats.m_Kills / (float)(p->m_Stats.m_Shots == 0 ? 1: p->m_Stats.m_Shots)) * 100.f, p->m_Stats.m_GrabsNormal, p->m_Stats.m_GrabsTeam, p->m_Stats.m_GrabsGold, p->m_Stats.m_GrabsGreen, p->m_Stats.m_GrabsPurple, p->m_Stats.m_GrabsFalse, p->m_Stats.m_Deaths, p->m_Stats.m_UnfreezingHammerHits, p->m_Stats.m_Unfreezes);
+		"╚══════════════════════════\n", p->m_Stats.m_Kills, p->m_Stats.m_Hits, (p->m_Stats.m_Hits != 0) ? (float)((float)p->m_Stats.m_Kills / (float)p->m_Stats.m_Hits) : (float)p->m_Stats.m_Kills, p->m_Stats.m_Shots, ((float)p->m_Stats.m_Kills / (float)(p->m_Stats.m_Shots == 0 ? 1: p->m_Stats.m_Shots)) * 100.f, p->m_Stats.m_GrabsNormal, p->m_Stats.m_GrabsTeam, p->m_Stats.m_GrabsGold, p->m_Stats.m_GrabsGreen, p->m_Stats.m_GrabsPurple, p->m_Stats.m_GrabsWrong, p->m_Stats.m_Deaths, p->m_Stats.m_UnfreezingHammerHits, p->m_Stats.m_Unfreezes);
 
 	CNetMsg_Sv_Motd Msg;
 	Msg.m_pMessage = buff;
@@ -2130,7 +2130,7 @@ void CGameContext::SendRoundStats() {
 		SendChatTarget(i, buff);
 		str_format(buff, 300, "║Gold/Green/Purple: %d/%d/%d", p->m_Stats.m_GrabsGold, p->m_Stats.m_GrabsGreen, p->m_Stats.m_GrabsPurple);
 		SendChatTarget(i, buff);
-		str_format(buff, 300, "║False: %d", p->m_Stats.m_GrabsFalse);
+		str_format(buff, 300, "║Wrong: %d", p->m_Stats.m_GrabsWrong);
 		SendChatTarget(i, buff);
 		str_format(buff, 300, "║Deaths(while frozen): %d", p->m_Stats.m_Deaths);
 		SendChatTarget(i, buff);

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -861,7 +861,7 @@ bool IGameController::UseFakeTeams(){
 	return false;
 }
 
-bool IGameController::IsFalseSpike(int Team, int SpikeFlags) {
+bool IGameController::IsWrongSpike(int Team, int SpikeFlags) {
 	if (Team == TEAM_BLUE && (SpikeFlags&(CCollision::COLFLAG_SPIKE_RED)) != 0) return true;
 	else if (Team == TEAM_RED && (SpikeFlags&(CCollision::COLFLAG_SPIKE_BLUE)) != 0) return true;
 	return false;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -157,7 +157,7 @@ public:
 
 	virtual void PostReset();
 
-	virtual bool IsFalseSpike(int Team, int SpikeFlags);
+	virtual bool IsWrongSpike(int Team, int SpikeFlags);
 };
 
 #endif

--- a/src/game/server/gamemodes/fng2.cpp
+++ b/src/game/server/gamemodes/fng2.cpp
@@ -266,9 +266,9 @@ int CGameControllerFNG2::OnCharacterDeath(class CCharacter *pVictim, class CPlay
 				m_aTeamscore[TEAM_RED] += m_Config.m_SvTeamScoreSpikeTeam;
 				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeTeam);
 			} else {
-				pKiller->m_Stats.m_GrabsFalse++;				
-				m_aTeamscore[TEAM_BLUE] += m_Config.m_SvTeamScoreSpikeFalse;
-				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeFalse);
+				pKiller->m_Stats.m_GrabsWrong++;				
+				m_aTeamscore[TEAM_BLUE] += m_Config.m_SvTeamScoreSpikeWrong;
+				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeWrong);
 			}
 			pVictim->GetPlayer()->m_RespawnTick = Server()->Tick()+Server()->TickSpeed()*.5f;
 		} else if(Weapon == WEAPON_SPIKE_BLUE){
@@ -278,9 +278,9 @@ int CGameControllerFNG2::OnCharacterDeath(class CCharacter *pVictim, class CPlay
 				m_aTeamscore[TEAM_BLUE] += m_Config.m_SvTeamScoreSpikeTeam;
 				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeTeam);
 			} else {
-				pKiller->m_Stats.m_GrabsFalse++;
-				m_aTeamscore[TEAM_RED] += m_Config.m_SvTeamScoreSpikeFalse;
-				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeFalse);
+				pKiller->m_Stats.m_GrabsWrong++;
+				m_aTeamscore[TEAM_RED] += m_Config.m_SvTeamScoreSpikeWrong;
+				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeWrong);
 			}
 			pVictim->GetPlayer()->m_RespawnTick = Server()->Tick()+Server()->TickSpeed()*.5f;
 		} else if(Weapon == WEAPON_SPIKE_GREEN){

--- a/src/game/server/gamemodes/fng2_4teams.cpp
+++ b/src/game/server/gamemodes/fng2_4teams.cpp
@@ -458,9 +458,9 @@ int CGameControllerFNG24Teams::OnCharacterDeath(class CCharacter *pVictim, class
 				m_a4Teamscore[TEAM_RED] += m_Config.m_SvTeamScoreSpikeTeam;
 				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeTeam);
 			} else {
-				pKiller->m_Stats.m_GrabsFalse++;				
-				m_a4Teamscore[pKiller->GetTeam()] += m_Config.m_SvTeamScoreSpikeFalse;
-				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeFalse);
+				pKiller->m_Stats.m_GrabsWrong++;				
+				m_a4Teamscore[pKiller->GetTeam()] += m_Config.m_SvTeamScoreSpikeWrong;
+				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeWrong);
 			}
 			pVictim->GetPlayer()->m_RespawnTick = Server()->Tick()+Server()->TickSpeed()*.5f;
 		} else if(Weapon == WEAPON_SPIKE_BLUE){
@@ -470,9 +470,9 @@ int CGameControllerFNG24Teams::OnCharacterDeath(class CCharacter *pVictim, class
 				m_a4Teamscore[TEAM_BLUE] += m_Config.m_SvTeamScoreSpikeTeam;
 				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeTeam);
 			} else {
-				pKiller->m_Stats.m_GrabsFalse++;
-				m_a4Teamscore[pKiller->GetTeam()] += m_Config.m_SvTeamScoreSpikeFalse;
-				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeFalse);
+				pKiller->m_Stats.m_GrabsWrong++;
+				m_a4Teamscore[pKiller->GetTeam()] += m_Config.m_SvTeamScoreSpikeWrong;
+				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeWrong);
 			}
 			pVictim->GetPlayer()->m_RespawnTick = Server()->Tick()+Server()->TickSpeed()*.5f;
 		} else if(Weapon == WEAPON_SPIKE_GREEN){
@@ -482,9 +482,9 @@ int CGameControllerFNG24Teams::OnCharacterDeath(class CCharacter *pVictim, class
 				m_a4Teamscore[TEAM_GREEN] += m_Config.m_SvTeamScoreSpikeTeam;
 				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeTeam);
 			} else {
-				pKiller->m_Stats.m_GrabsFalse++;
-				m_a4Teamscore[pKiller->GetTeam()] += m_Config.m_SvTeamScoreSpikeFalse;
-				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeFalse);
+				pKiller->m_Stats.m_GrabsWrong++;
+				m_a4Teamscore[pKiller->GetTeam()] += m_Config.m_SvTeamScoreSpikeWrong;
+				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeWrong);
 			}
 			pVictim->GetPlayer()->m_RespawnTick = Server()->Tick()+Server()->TickSpeed()*.5f;
 		} else if(Weapon == WEAPON_SPIKE_PURPLE){
@@ -494,9 +494,9 @@ int CGameControllerFNG24Teams::OnCharacterDeath(class CCharacter *pVictim, class
 				m_a4Teamscore[TEAM_PURPLE] += m_Config.m_SvTeamScoreSpikeTeam;
 				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeTeam);
 			} else {
-				pKiller->m_Stats.m_GrabsFalse++;
-				m_a4Teamscore[pKiller->GetTeam()] += m_Config.m_SvTeamScoreSpikeFalse;
-				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeFalse);
+				pKiller->m_Stats.m_GrabsWrong++;
+				m_a4Teamscore[pKiller->GetTeam()] += m_Config.m_SvTeamScoreSpikeWrong;
+				if(pKiller->GetCharacter()) GameServer()->MakeLaserTextPoints(pKiller->GetCharacter()->m_Pos, pKiller->GetCID(), m_Config.m_SvPlayerScoreSpikeWrong);
 			}
 			pVictim->GetPlayer()->m_RespawnTick = Server()->Tick()+Server()->TickSpeed()*.5f;
 		} else if(Weapon == WEAPON_SPIKE_GOLD){
@@ -940,7 +940,7 @@ void CGameControllerFNG24Teams::CmdJoinTeam(CGameContext* pContext, int pClientI
 	}
 }
 
-bool CGameControllerFNG24Teams::IsFalseSpike(int Team, int SpikeFlags) {
+bool CGameControllerFNG24Teams::IsWrongSpike(int Team, int SpikeFlags) {
 	if (Team == TEAM_BLUE && (SpikeFlags&(CCollision::COLFLAG_SPIKE_RED | CCollision::COLFLAG_SPIKE_GREEN | CCollision::COLFLAG_SPIKE_PURPLE)) != 0) return true;
 	else if (Team == TEAM_RED && (SpikeFlags&(CCollision::COLFLAG_SPIKE_BLUE | CCollision::COLFLAG_SPIKE_GREEN | CCollision::COLFLAG_SPIKE_PURPLE)) != 0) return true;
 	else if (Team == TEAM_GREEN && (SpikeFlags&(CCollision::COLFLAG_SPIKE_RED | CCollision::COLFLAG_SPIKE_BLUE | CCollision::COLFLAG_SPIKE_PURPLE)) != 0) return true;

--- a/src/game/server/gamemodes/fng2_4teams.h
+++ b/src/game/server/gamemodes/fng2_4teams.h
@@ -39,7 +39,7 @@ public:
 	
 	static void CmdJoinTeam(CGameContext* pContext, int pClientID, const char** pArgs, int ArgNum);
 
-	virtual bool IsFalseSpike(int Team, int SpikeFlags);
+	virtual bool IsWrongSpike(int Team, int SpikeFlags);
 protected:
 	void EndRound();
 	

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -378,11 +378,11 @@ void CPlayer::CalcScore(){
 	if(g_Config.m_SvScoreDisplay == 0){
 		m_Score = m_Stats.m_Kills + m_Stats.m_Unfreezes;
 		//TODO: make this configurable
-		m_Score += (m_Stats.m_GrabsNormal * g_Config.m_SvPlayerScoreSpikeNormal) + (m_Stats.m_GrabsTeam * g_Config.m_SvPlayerScoreSpikeTeam) + (m_Stats.m_GrabsFalse * g_Config.m_SvPlayerScoreSpikeFalse) + (m_Stats.m_GrabsGold * g_Config.m_SvPlayerScoreSpikeGold) + (m_Stats.m_GrabsGreen * g_Config.m_SvPlayerScoreSpikeGreen) + (m_Stats.m_GrabsPurple * g_Config.m_SvPlayerScoreSpikePurple);
+		m_Score += (m_Stats.m_GrabsNormal * g_Config.m_SvPlayerScoreSpikeNormal) + (m_Stats.m_GrabsTeam * g_Config.m_SvPlayerScoreSpikeTeam) + (m_Stats.m_GrabsWrong * g_Config.m_SvPlayerScoreSpikeWrong) + (m_Stats.m_GrabsGold * g_Config.m_SvPlayerScoreSpikeGold) + (m_Stats.m_GrabsGreen * g_Config.m_SvPlayerScoreSpikeGreen) + (m_Stats.m_GrabsPurple * g_Config.m_SvPlayerScoreSpikePurple);
 	} else {
 		m_Score = m_Stats.m_Kills + m_Stats.m_Unfreezes - m_Stats.m_Hits;
 		//TODO: make this configurable
-		m_Score += (m_Stats.m_GrabsNormal * g_Config.m_SvPlayerScoreSpikeNormal) + (m_Stats.m_GrabsTeam * g_Config.m_SvPlayerScoreSpikeTeam) + (m_Stats.m_GrabsFalse * g_Config.m_SvPlayerScoreSpikeFalse) + (m_Stats.m_GrabsGold * g_Config.m_SvPlayerScoreSpikeGold) + (m_Stats.m_GrabsGreen * g_Config.m_SvPlayerScoreSpikeGreen) + (m_Stats.m_GrabsPurple * g_Config.m_SvPlayerScoreSpikePurple) - (m_Stats.m_Deaths * g_Config.m_SvPlayerScoreSpikeNormal);
+		m_Score += (m_Stats.m_GrabsNormal * g_Config.m_SvPlayerScoreSpikeNormal) + (m_Stats.m_GrabsTeam * g_Config.m_SvPlayerScoreSpikeTeam) + (m_Stats.m_GrabsWrong * g_Config.m_SvPlayerScoreSpikeWrong) + (m_Stats.m_GrabsGold * g_Config.m_SvPlayerScoreSpikeGold) + (m_Stats.m_GrabsGreen * g_Config.m_SvPlayerScoreSpikeGreen) + (m_Stats.m_GrabsPurple * g_Config.m_SvPlayerScoreSpikePurple) - (m_Stats.m_Deaths * g_Config.m_SvPlayerScoreSpikeNormal);
 		m_Score -= m_Stats.m_Teamkills;	
 	}
 }

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -63,7 +63,7 @@ public:
 		int m_Kills; //kills made by weapon
 		int m_GrabsNormal; //kills made by grabbing oponents into spikes - normal spikes
 		int m_GrabsTeam; //kills made by grabbing oponents into spikes - team spikes
-		int m_GrabsFalse; //kills made by grabbing oponents into spikes - oponents spikes
+		int m_GrabsWrong; //kills made by grabbing oponents into spikes - oponents spikes
 		int m_GrabsGold; //kills made by grabbing oponents into spikes - golden spikes
 		int m_GrabsGreen; //kills made by grabbing oponents into spikes - for non 4-teams fng green spikes
 		int m_GrabsPurple; //kills made by grabbing oponents into spikes - for non 4-teams fng purple spikes

--- a/src/game/variables_special.h
+++ b/src/game/variables_special.h
@@ -10,16 +10,16 @@ MACRO_CONFIG_INT(SvTeamScoreSpikeTeam, sv_team_score_team, 10, 0, 100, CFGFLAG_S
 MACRO_CONFIG_INT(SvTeamScoreSpikeGold, sv_team_score_gold, 10, 0, 100, CFGFLAG_SERVER, "Points a team receives for grabbing into golden spikes")
 MACRO_CONFIG_INT(SvTeamScoreSpikeGreen, sv_team_score_green, 10, 0, 100, CFGFLAG_SERVER, "Points a team receives for grabbing into green spikes(non 4-teams fng only)")
 MACRO_CONFIG_INT(SvTeamScoreSpikePurple, sv_team_score_purple, 10, 0, 100, CFGFLAG_SERVER, "Points a team receives for grabbing into purple spikes(non 4-teams fng only)")
-MACRO_CONFIG_INT(SvTeamScoreSpikeFalse, sv_team_score_false, -2, -100, 0, CFGFLAG_SERVER, "Points a team receives for grabbing into opponents spikes")
+MACRO_CONFIG_INT(SvTeamScoreSpikeWrong, sv_team_score_wrong, -2, -100, 0, CFGFLAG_SERVER, "Points a team receives for grabbing into opponents spikes")
 
 MACRO_CONFIG_INT(SvPlayerScoreSpikeNormal, sv_player_score_normal, 3, 0, 100, CFGFLAG_SERVER, "Points a player receives for grabbing into normal spikes")
 MACRO_CONFIG_INT(SvPlayerScoreSpikeTeam, sv_player_score_team, 5, 0, 100, CFGFLAG_SERVER, "Points a player receives for grabbing into team spikes")
 MACRO_CONFIG_INT(SvPlayerScoreSpikeGold, sv_player_score_gold, 7, 0, 100, CFGFLAG_SERVER, "Points a player receives for grabbing into golden spikes")
 MACRO_CONFIG_INT(SvPlayerScoreSpikeGreen, sv_player_score_green, 5, 0, 100, CFGFLAG_SERVER, "Points a player receives for grabbing into green spikes(non 4-teams fng only)")
 MACRO_CONFIG_INT(SvPlayerScoreSpikePurple, sv_player_score_purple, 6, 0, 100, CFGFLAG_SERVER, "Points a player receives for grabbing into purple spikes(non 4-teams fng only)")
-MACRO_CONFIG_INT(SvPlayerScoreSpikeFalse, sv_player_score_false, -5, -100, 0, CFGFLAG_SERVER, "Points a player receives for grabbing into opponents spikes")
+MACRO_CONFIG_INT(SvPlayerScoreSpikeWrong, sv_player_score_wrong, -5, -100, 0, CFGFLAG_SERVER, "Points a player receives for grabbing into opponents spikes")
 
-MACRO_CONFIG_INT(SvFalseSpikeFreeze, sv_false_spike_freeze, 5, 0, 60, CFGFLAG_SERVER, "The time, in seconds, a player gets frozen, if he grabbed a frozen opponent into the opponents spikes")
+MACRO_CONFIG_INT(SvWrongSpikeFreeze, sv_wrong_spike_freeze, 5, 0, 60, CFGFLAG_SERVER, "The time, in seconds, a player gets frozen, if he grabbed a frozen opponent into the opponents spikes")
 MACRO_CONFIG_INT(SvHitFreeze, sv_hit_freeze, 10, 0, 60, CFGFLAG_SERVER, "The time, in seconds, a player gets frozen, if he gets shot")
 
 MACRO_CONFIG_INT(SvEmoticonDelay, sv_emoticon_delay, 3, 0, 10, CFGFLAG_SERVER, "The delay a player can use emotes")


### PR DESCRIPTION
The word "wrong" fits better for enemy spikes than "false". To me it just sounds better. And to quote the native player Ewan:

> they’re equally correct imo
> but when talking about teams i’d tend towards wrong
> bcs there’s no true team, just the one you’re on

Possible alternatives are:
- opponent
- enemey

But wrong sounds the most obvious in all the cases. Otherwise it can be confused with for example spiking an enemy. Not with the spike that belongs to the enemy. Also what does enemy spike mean? The spike where you put the enemys? The spike where the enemys put you? The word "wrong" is clear in these cases.

This came up in ddnet-insta where the same config is being implemented. And I would like to share as much user facing variable names as possible to make the life of the users easier and more consistent.

https://github.com/ddnet-insta/ddnet-insta/pull/327#discussion_r1994325106

Here me testing if ``sv_wrong_spike_freeze 60`` still works as expected:

![fng2_sv_wrong_spike_freeze_60](https://github.com/user-attachments/assets/134cf5f0-635e-46db-8f65-fc88463e61c9)

How I verified false was removed everywhere:

```
main@debian:~/Desktop/git/teeworlds-fng2-mod$ grep -ri 'spike.*false' --exclude-dir=.git
other/mysql/include/boost_1_59_0/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp:    // allow spikes (false indicates: do not remove spikes)
main@debian:~/Desktop/git/teeworlds-fng2-mod$ grep -ri 'false.*spike' --exclude-dir=.git
other/mysql/include/boost_1_59_0/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp:    // allow spikes (false indicates: do not remove spikes)
other/mysql/include/boost_1_59_0/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp:                    false, false // do not reverse; do not remove spikes
other/mysql/include/boost_1_59_0/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp:                    false // do not remove spikes for linear geometries
```